### PR TITLE
Fixing footer not displaying correctly on small screens

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -26,7 +26,7 @@ const Footer = () => {
 
         <div className="flex md:flex-row flex-col md:items-center justify-between">
           <p className="font-semibold text-gray text-xs">Developed by Gustavo Zavadniak as a study case.</p>
-          <div className="flex">
+          <div className="flex flex-wrap">
             {footerLinks.map((link, i) => (
               <p key={link} className="font-semibold text-gray text-xs">
                 {link}{' '}


### PR DESCRIPTION
### Solution

`flex-wrap` Wrapping the outer div with flex-wrap could be a simple fix for this issue. It's effective for my needs.

### Issue
Issue: #2

```bash
<div className="flex flex-wrap">
  {footerLinks.map((link, i) => (
    <p key={link} className="font-semibold text-gray text-xs">
      {link}{' '}
      {i !== footerLinks.length - 1 && (
        <span className="mx-2"> | </span>
      )}
    </p>
  ))}
</div>
```

![IssueSolved](https://github.com/Zidasss/ApplePage_Project/assets/110608079/ac4d01e1-c740-42a7-8b8c-122adc0a59ea)
